### PR TITLE
Link semantics to code

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,8 +6,8 @@
   "description": "Drag and drop pieces of text to create complete sentences.",
 >>>>>>> Stashed changes
   "majorVersion": 1,
-  "minorVersion": 0,
-  "patchVersion": 0,
+  "minorVersion": 8,
+  "patchVersion": 14,
   "coreApi": {
     "majorVersion": 1,
     "minorVersion": 19

--- a/library.json
+++ b/library.json
@@ -1,10 +1,6 @@
 {
   "title": "Parsons Puzzle",
-<<<<<<< Updated upstream
-  "description": "Reorder and indent code lines to create a working program.",
-=======
   "description": "Drag and drop pieces of text to create complete sentences.",
->>>>>>> Stashed changes
   "majorVersion": 1,
   "minorVersion": 8,
   "patchVersion": 14,


### PR DESCRIPTION
changed version numbers back in library.json

needs later version to update drag-text, otherwise it does not load in Drupal

