### PR TITLE
drop zone autosizing

### DIFF
--- a/src/scripts/drag-text.js
+++ b/src/scripts/drag-text.js
@@ -809,51 +809,30 @@ H5P.ParsonsPuzzle = (function ($, Question, ConfirmationDialog) {
   ParsonsPuzzle.prototype.addDropzoneWidth = function () {
     var self = this;
     var widest = 0;
-    var widestDragagble = 0;
-    var fontSize = parseInt(this.$inner.css('font-size'), 10);
-    var staticMinimumWidth = 3 * fontSize;
-    var staticPadding = fontSize; // Needed to make room for feedback icons
+    var widestDraggable = 0;
+    var staticMinimumWidth = 3;
 
     //Find widest draggable
     this.draggables.forEach(function (draggable) {
-      var $draggableElement = draggable.getDraggableElement();
+      
+      var nonHTMLCode = draggable.codeLine.code.replace(/&quot;/g, "\"");
+      var width = nonHTMLCode.length + draggable.codeLine.indent;
 
-      //Find the initial natural width of the draggable.
-      var $tmp = $draggableElement.clone().css({
-        'position': 'absolute',
-        'white-space': 'nowrap',
-        'width': 'auto',
-        'padding': 0,
-        'margin': 0
-      }).html(draggable.getAnswerText())
-        .appendTo($draggableElement.parent());
-      var width = $tmp.outerWidth();
+      widestDraggable = width > widestDraggable ? width : widestDraggable; 
+      widest = widestDraggable;
 
-      widestDragagble = width > widestDragagble ? width : widestDragagble;
-
-      // Measure how big truncated draggable should be
-      if ($tmp.text().length >= 20) {
-        $tmp.html(draggable.getShortFormat());
-        width = $tmp.width();
+      if (width + staticMinimumWidth > widest) {
+        widest = width + staticMinimumWidth;
       }
+    }); 
 
-      if (width + staticPadding > widest) {
-        widest = width + staticPadding;
-      }
-      $tmp.remove();
-    });
-    // Set min size
-    if (widest < staticMinimumWidth) {
-      widest = staticMinimumWidth;
-    }
-    this.widestDraggable = widestDragagble;
-
+    this.widestDraggable = widestDraggable;
     this.widest = widest;
 
-    this.widest = 200;
     //Adjust all droppable to widest size.
     this.droppables.forEach(function (droppable) {
-      droppable.getDropzone().width(self.widest);
+      console.log(self.widest+"em");
+      droppable.getDropzone().width(self.widest+"em");
     });
   };
 

--- a/src/scripts/draggable.js
+++ b/src/scripts/draggable.js
@@ -20,10 +20,13 @@ H5P.TextDraggable = (function ($) {
     self.initialIndex = index;
 
     self.shortFormat = self.codeLine.code;
+    /* currently we do not shorten code lines, but left as a 
+       possible extension to look at later
     //Shortens the draggable string if inside a dropbox.
     if (self.shortFormat.length > 20) {
       self.shortFormat = self.shortFormat.slice(0, 17) + '...';
     }
+    */
   }
 
   Draggable.prototype = Object.create(H5P.EventDispatcher.prototype);


### PR DESCRIPTION
drop zone width is now set by the widest draggable (including indentation).

commented out code that changes code lines to have ...  existing code does this when code line is > 20.  Eventually may reuse when code line can not be displayed on screen - but TBD