### PR TITLE
Update parsons-puzzle.js

### DIFF
--- a/src/scripts/parsons-puzzle.js
+++ b/src/scripts/parsons-puzzle.js
@@ -384,6 +384,9 @@ import Mouse from 'h5p-lib-controls/src/scripts/ui/mouse';
       self.stopWatch.reset();
       self.resetTask();
       self.$draggables.css('display','inline');
+      self.hideButton('try-again');
+    }, self.initShowTryAgainButton || false, {
+      'aria-label': self.params.a11yRetry,
     });
   };
 


### PR DESCRIPTION
hide retry button until check is ticked.  added a11y accessibility label to retry.